### PR TITLE
Add windows runner for tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,17 @@ When executing in production, the following patterns are generally recommended:
     bin/tap-mssql  --config config.json --sync | target-csv > state.json
     ```
 
-3. Instructions to execute using docker:
+3. Executing using the `tap-mssql` batch script (Windows only):
+
+    ```powershell
+    # Discover metadata catalog:
+    bin/tap-mssql.bat --config config.json --discover > catalog.json
+
+    # Execute sync to target-csv (for example):
+    bin/tap-mssql.bat  --config config.json --sync | target-csv > state.json
+    ```
+
+4. Instructions to execute using docker:
     * ***TK - TODO: Which image name to use in place of `local/tap-mssql` below?***
     * Build the docker image:
 

--- a/bin/tap-mssql.bat
+++ b/bin/tap-mssql.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+cd C:\Repos_Other\tap-mssql\src
+lein run -m tap-mssql.core %*
+cd -

--- a/bin/tap-mssql.bat
+++ b/bin/tap-mssql.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
-cd C:\Repos_Other\tap-mssql\src
+setlocal
+cd /d %~dp0
+cd ..\src
 lein run -m tap-mssql.core %*
-cd -

--- a/bin/tap-mssql.bat
+++ b/bin/tap-mssql.bat
@@ -1,5 +1,8 @@
 @ECHO OFF
+REM setlocal limits context changes to just within batch file
 setlocal
+REM change current directory to the location of batch file
 cd /d %~dp0
+REM lein must be run in context of src folder
 cd ..\src
 lein run -m tap-mssql.core %*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ _These instructions require the [Chocolatey](chocolatey.org) package manager to 
     cd c:\Files\Source
 
     # Download the tap:
-    git clone https://github.com/singer-io/tap-mssql.git
+    git clone https://github.com/slalom/tap-mssql.git
     ```
 
 5. Test `tap-mssql` using `lein`:


### PR DESCRIPTION
# Description of change
Adds batch file that can be run on windows command line or via tapdance that correctly suppresses commands in file so that resulting catalog.json is properly formatted

# QA steps
 - [x] automated tests passing
 - [x] manual qa steps passing (list below)
 
# Risks
~~Hard-coded batch references are bad, but appear unavoidable.  Maybe have it use a more standard location?~~
Fixed hard-coded references in batch file

# Rollback steps
 - revert this branch
