### PR TITLE
Migrate to GitHub Container Registry

### DIFF
--- a/.github/workflows/cicd-docker-build.yml
+++ b/.github/workflows/cicd-docker-build.yml
@@ -15,7 +15,7 @@ jobs:
         # Ref: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#example-of-updated-workflow
         run: |
           export IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY}
-          echo "${GITHUB_ACCESS_TOKEN}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+          echo "${ACCESS_TOKEN_FOR_DOCKER}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
           docker pull $IMAGE_NAME:latest | true
           docker build . -t $IMAGE_NAME:build${{ github.run_number }} --cache-from IMAGE_NAME:latest
           docker push $IMAGE_NAME:build${{ github.run_number }}

--- a/.github/workflows/cicd-docker-build.yml
+++ b/.github/workflows/cicd-docker-build.yml
@@ -12,9 +12,10 @@ jobs:
       - name: Clone git repo
         uses: actions/checkout@v1
       - name: Docker build
-        # Ref: https://github.com/actions/starter-workflows/issues/66#issuecomment-679029894
+        # Ref: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#example-of-updated-workflow
         run: |
-          export IMAGE_NAME=docker.pkg.github.com/${GITHUB_REPOSITORY}/tap-mssql:build${{ github.run_number }}
-          echo "${{ github.token }}" | docker login https://docker.pkg.github.com -u ${GITHUB_ACTOR} --password-stdin
-          docker build -t $IMAGE_NAME .
-          docker push $IMAGE_NAME
+          export IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY}
+          echo "${GITHUB_ACCESS_TOKEN}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+          docker pull $IMAGE_NAME:latest | true
+          docker build . -t $IMAGE_NAME:build${{ github.run_number }} --cache-from IMAGE_NAME:latest
+          docker push $IMAGE_NAME:build${{ github.run_number }}

--- a/.github/workflows/cicd-docker-build.yml
+++ b/.github/workflows/cicd-docker-build.yml
@@ -15,7 +15,7 @@ jobs:
         # Ref: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#example-of-updated-workflow
         run: |
           export IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY}
-          echo "${ACCESS_TOKEN_FOR_DOCKER}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+          echo "${ACCESS_TOKEN_FOR_DOCKER}" | docker login https://ghcr.io --password-stdin -u "aj.steers@slalom.com"
           docker pull $IMAGE_NAME:latest | true
           docker build . -t $IMAGE_NAME:build${{ github.run_number }} --cache-from IMAGE_NAME:latest
           docker push $IMAGE_NAME:build${{ github.run_number }}

--- a/.github/workflows/cicd-docker-build.yml
+++ b/.github/workflows/cicd-docker-build.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v1
       - name: Docker build
         # Ref: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#example-of-updated-workflow
+        env: # Or as an environment variable
+          ACCESS_TOKEN_FOR_DOCKER: ${{ secrets.ACCESS_TOKEN_FOR_DOCKER }}
         run: |
           export IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY}
           echo "${ACCESS_TOKEN_FOR_DOCKER}" | docker login https://ghcr.io --password-stdin -u "aj.steers@slalom.com"

--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ When executing in production, the following patterns are generally recommended:
     ```
 
 3. Instructions to execute using docker:
-    * ***TK - TODO: Which image name to use in place of `local/tap-mssql` below?***
-    * Build the docker image:
+
+    * Build the docker image (optional):
 
         ```bash
-        docker build -t local/tap-mssql .
+        docker build -t ghcr.io/slalom/tap-mssql:latest .
         ```
 
     * Run using docker:
 
         ```bash
         # Discover metadata catalog:
-        docker run --rm -it -v .:/home/tap-mssql local/tap-mssql --config config.json --discover > catalog.json
+        docker run --rm -it -v .:/home/tap-mssql ghcr.io/slalom/tap-mssql:latest --config config.json --discover > catalog.json
 
         # Execute sync to target-csv (for example):
-        docker run --rm -it -v .:/home/tap-mssql local/tap-mssql --config config.json --sync | target-csv > state.json
+        docker run --rm -it -v .:/home/tap-mssql ghcr.io/slalom/tap-mssql:latest --config config.json --sync | target-csv > state.json
         ```
 
 ### Other ways to run and test


### PR DESCRIPTION
# Description of change

This migrates the docker images to GitHub container registry, which is a more docker-specialized repository than the Package repository. 
For reference: https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images

## Access Token for Auth:

This update adds an access token for the CI/CD workflow to create and push docker images.

![image](https://user-images.githubusercontent.com/18150651/107287882-708ccd80-6a17-11eb-916f-599ccf09a475.png)


# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
